### PR TITLE
Add required parameter to example: api_timeout.

### DIFF
--- a/config_example.yaml
+++ b/config_example.yaml
@@ -8,3 +8,4 @@ challenge:
   difficulty: 2 # required, 1 = easy, 2 = medium, 3 = hard
 overpass_query: 'node(40.5,-112.2,40.8,-111.7)[amenity~"shop|restaurant"][opening_hours!~"."]' # required. An overpass query QL stub (without the out statements)
 maproulette_server: 'http://dev.maproulette.org/' # required
+api_timeout: 60


### PR DESCRIPTION
I saw this when I tried to run. The config_schema object clearly states that the api_timeout is required.

```
 $ ./mmm.py --new config_example.yaml

 Hey! This is the Magical MapRoulette Machine.

 It lets you create a real MapRoulette challenge
 from an Overpass query. Pretty neat. Magical!

 Traceback (most recent call last):
   File "./mmm.py", line 379, in <module>
     main()
   File "./mmm.py", line 349, in main
     process_config_file(args.config_file)
   File "./mmm.py", line 78, in process_config_file
     raise e
 voluptuous.MultipleInvalid: required key not provided @ data['api_timeout']
```
